### PR TITLE
Add version restriction for rufus-scheduler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec
 
 group :test do

--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency(%q<redis>, [">= 2.0.1"])
   s.add_runtime_dependency(%q<resque>, [">= 1.20.0"])
-  s.add_runtime_dependency(%q<rufus-scheduler>, [">= 0"])
+  s.add_runtime_dependency(%q<rufus-scheduler>, ["~> 2.0"])
 end


### PR DESCRIPTION
This is the same version restriction that resque-scheduler still
has on master.

Also switch to https for rubygems as http is deprecated.
