### PR TITLE
GROW-350: Bump redis to 3.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 ## 2.1.0 (2020-06-08)
 
-* Supports redis up to v3.0
+* Now supports redis < 3.1
 
 ## 2.0.0
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,8 @@
 ## 2.1.0 (2020-06-08)
 
-* Now supports redis < 3.1
+* Support redis < 3.1
+* Add version restrictions for rufus-scheduler, resque, and mocha
+* Add all-in-one target for Yesware CI
 
 ## 2.0.0
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## 2.1.0 (2020-06-08)
+
+* Supports redis up to v3.0
+
 ## 2.0.0
 
 * Add support for Resque.inline configuration (carlosantoniodasilva)

--- a/lib/resque_scheduler/version.rb
+++ b/lib/resque_scheduler/version.rb
@@ -1,3 +1,3 @@
 module ResqueScheduler
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end

--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables  = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact
   s.require_path = 'lib'
 
-  s.add_runtime_dependency 'redis', '~> 3.0.0'
+  s.add_runtime_dependency 'redis', '>= 2.2.2', '< 3.1'
   s.add_runtime_dependency 'resque', '>= 1.22'
   s.add_runtime_dependency 'rufus-scheduler', '~> 2.0'
 end

--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables  = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact
   s.require_path = 'lib'
 
-  s.add_runtime_dependency 'redis', '~> 2.2.2'
+  s.add_runtime_dependency 'redis', '~> 3.0.0'
   s.add_runtime_dependency 'resque', '>= 1.22'
   s.add_runtime_dependency 'rufus-scheduler', '~> 2.0'
 end


### PR DESCRIPTION
Bumping redis in preparation for the rails 5.x upgrade.  I opted to explicitly define lower and upper bounds for accepted versions to maintain backwards compatibility with other apps that might use this repo while also having `redis` locked to something below 3.0.